### PR TITLE
Converted is_hashed_password as logical

### DIFF
--- a/R/credentials-db.R
+++ b/R/credentials-db.R
@@ -26,7 +26,7 @@
 #' @importFrom DBI dbConnect dbDisconnect dbWriteTable
 #' @importFrom RSQLite SQLite
 #' @importFrom scrypt hashPassword
-#' 
+#'
 #' @seealso \code{\link{read_db_decrypt}}
 #'
 #' @examples
@@ -198,7 +198,7 @@ write_db_encrypt <- function(conn, value, name = "credentials", passphrase = NUL
     if(!"is_hashed_password" %in% colnames(value)){
       value$is_hashed_password <- FALSE
     }
-    to_hash <- which(!value$is_hashed_password)
+    to_hash <- which(!as.logical(value$is_hashed_password))
     if(length(to_hash) > 0){
       # store hashed password
       value$password[to_hash] <- sapply(value$password[to_hash], function(x) scrypt::hashPassword(x))


### PR DESCRIPTION
Hi,

Thanks for this great package.

`create_db` return an error when is_hashed_password = TRUE in the credentials data frame, as bellow : 

``` r
credentials <- data.frame(
  user = c("admin"), 
  password = c(scrypt::hashPassword("admin")),
  start = c(NA), # optional (all others)
  expire = c(NA),
  admin = c(TRUE),
  comment = "Default admin user (change the password) .",
  is_hashed_password = TRUE,
  stringsAsFactors = FALSE
)



shinymanager::create_db(
  credentials_data = credentials,
  sqlite_path =":memory:",
  passphrase = NULL)
#> Error in stopifnot(length(dbname) == 1, !is.na(dbname)): object 'path' not found
```

<sup>Created on 2020-07-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>


Maybe not the best solution, but here a simple modification to make sure that `is_hashed_password` is evaluated as logical in write_db_encrypt function.

