### PR TITLE
keep queries in tact through auth

### DIFF
--- a/R/module-auth.R
+++ b/R/module-auth.R
@@ -240,7 +240,7 @@ auth_server <- function(input, output, session,
       if (isTRUE(use_token)) {
         # add_token(token, as.list(res_auth$user_info))
         .tok$add(token, as.list(res_auth$user_info))
-        updateQueryString(queryString = paste0("?token=", token, "&language=", lan()$get_language()), session = session)
+        addAuthToQuery(session, token, lan()$get_language())
         session$reload()
       }
       

--- a/R/shiny-utils.R
+++ b/R/shiny-utils.R
@@ -71,7 +71,15 @@ resetQueryString <- function(session = getDefaultReactiveDomain()) {
   }
 }
 
-
+#  Add token to query string but leave rest of query (if any) in tact
+#' @importFrom shiny updateQueryString getQueryString getDefaultReactiveDomain
+addAuthToQuery <- function(session = getDefaultReactiveDomain(), token, language ) {
+  query <- getQueryString(session = session)
+  query$token <- token
+  query$language <- language
+  query <- paste(names(query), query, sep = "=", collapse="&")
+  updateQueryString(queryString = paste0("?", query), mode = "replace", session = session)
+}
 
 #' @importFrom htmltools tags doRenderTags
 #' @importFrom shiny icon


### PR DESCRIPTION
This suggested edit preserves query strings in the original request through the authorization process so that they are still in tact after authorization. 

(This is my first pull request ever so please advise if I can be more helpful).