### PR TITLE
add position none to FAB button

### DIFF
--- a/R/fab_button.R
+++ b/R/fab_button.R
@@ -17,7 +17,7 @@
 #'
 #' @example examples/fab_button.R
 fab_button <- function(...,
-                       position = c("none", "bottom-right", "top-right", "bottom-left", "top-left"),
+                       position = c("bottom-right", "top-right", "bottom-left", "top-left", "none"),
                        animation = c("slidein", "slidein-spring", "fountain", "zoomin"),
                        toggle = c("hover", "click"),
                        inputId = NULL,
@@ -34,7 +34,7 @@ fab_button <- function(...,
   toggle <- match.arg(toggle)
   animation <- match.arg(animation)
   position <- match.arg(position)
-  if (position == "none") return()
+  if (position == "none") return(NULL)
   position <- switch(
     position,
     "bottom-right" = "br",

--- a/R/fab_button.R
+++ b/R/fab_button.R
@@ -17,7 +17,7 @@
 #'
 #' @example examples/fab_button.R
 fab_button <- function(...,
-                       position = c("bottom-right", "top-right", "bottom-left", "top-left"),
+                       position = c("none", "bottom-right", "top-right", "bottom-left", "top-left"),
                        animation = c("slidein", "slidein-spring", "fountain", "zoomin"),
                        toggle = c("hover", "click"),
                        inputId = NULL,
@@ -34,6 +34,7 @@ fab_button <- function(...,
   toggle <- match.arg(toggle)
   animation <- match.arg(animation)
   position <- match.arg(position)
+  if (position == "none") return()
   position <- switch(
     position,
     "bottom-right" = "br",

--- a/man/fab_button.Rd
+++ b/man/fab_button.Rd
@@ -6,7 +6,7 @@
 \usage{
 fab_button(
   ...,
-  position = c("none", "bottom-right", "top-right", "bottom-left", "top-left"),
+  position = c("bottom-right", "top-right", "bottom-left", "top-left", "none"),
   animation = c("slidein", "slidein-spring", "fountain", "zoomin"),
   toggle = c("hover", "click"),
   inputId = NULL,

--- a/man/fab_button.Rd
+++ b/man/fab_button.Rd
@@ -6,7 +6,7 @@
 \usage{
 fab_button(
   ...,
-  position = c("bottom-right", "top-right", "bottom-left", "top-left"),
+  position = c("none", "bottom-right", "top-right", "bottom-left", "top-left"),
   animation = c("slidein", "slidein-spring", "fountain", "zoomin"),
   toggle = c("hover", "click"),
   inputId = NULL,


### PR DESCRIPTION
Hello,
i added a new option to FAB button position. The "none" option can be used in secure_app() to suppresses the FAB button.
see issue https://github.com/datastorm-open/shinymanager/issues/7
Inspired by legend.position none from ggplot package.
".shinymanager_logout" and ".shinymanager_admin" can still be used to create custom buttons.
