### PR TITLE
Avoid Font-awesome deprecation warnings

### DIFF
--- a/R/fab_button.R
+++ b/R/fab_button.R
@@ -54,7 +54,7 @@ fab_button <- function(...,
           `data-mfb-label` = label,
           class = "mfb-component__button--main action-button",
           icon("plus", class = "mfb-component__main-icon--resting"),
-          icon("times", class = "mfb-component__main-icon--active")
+          icon("xmark", class = "mfb-component__main-icon--active")
         ),
         tags$ul(
           class = "mfb-component__list",

--- a/R/module-admin.R
+++ b/R/module-admin.R
@@ -4,13 +4,13 @@
 #' @importFrom htmltools tags singleton tagList
 #' @importFrom shiny NS fluidRow column actionButton icon
 admin_ui <- function(id, lan = NULL) {
-  
+
   ns <- NS(id)
-  
+
   if(is.null(lan)){
     lan <- use_language()
   }
-  
+
   tagList(
     singleton(tags$head(
       tags$link(href="shinymanager/styles-admin.css", rel="stylesheet"),
@@ -22,10 +22,10 @@ admin_ui <- function(id, lan = NULL) {
         width = 10, offset = 1,
         # tags$h2(lan$get("Administrator mode")),
         # tags$br(), tags$br(),
-        
+
         tags$h3(icon("users"), lan$get("Users"), class = "text-primary"),
         tags$hr(),
-        
+
         actionButton(
           inputId = ns("add_user"),
           label = lan$get("Add a user"),
@@ -35,39 +35,39 @@ admin_ui <- function(id, lan = NULL) {
         ),
         tags$br(), tags$br(), tags$br(),
         DTOutput(outputId = ns("table_users")),
-        
+
         tags$br(),
-        
+
         actionButton(
           inputId = ns("select_all_users"),
           # label = lan$get("Select all shown users"),
           label = "",
           class = "btn-secondary pull-right",
           style = "margin-left: 5px",
-          icon = icon("check-square")
+          icon = icon("square-check")
         ),
-        
+
         actionButton(
           inputId = ns("edit_selected_users"),
           label = lan$get("Edit selected users"),
           class = "btn-primary pull-right disabled",
           style = "margin-left: 5px",
-          icon = icon("edit")
+          icon = icon("pen")
         ),
-        
+
         actionButton(
           inputId = ns("remove_selected_users"),
           label = lan$get("Remove selected users"),
           class = "btn-danger pull-right disabled",
-          icon = icon("trash-alt")
+          icon = icon("trash-can")
         ),
-        
+
         tags$br(),
-        
+
         if("users" %in% get_download()){
           list(
             tags$br(),tags$br(), tags$br(),
-            
+
             downloadButton(
               outputId = ns("download_users_database"),
               label = lan$get("Download Users file"),
@@ -76,14 +76,14 @@ admin_ui <- function(id, lan = NULL) {
             )
           )
         },
-        
+
         tags$h3(icon("key"), lan$get("Passwords"), class = "text-primary"),
         tags$hr(),
-        
+
         DTOutput(outputId = ns("table_pwds")),
-        
+
         tags$br(),
-        
+
         actionButton(
           inputId = ns("change_selected_allusers"),
           # label = lan$get("Select all shown users"),
@@ -92,18 +92,18 @@ admin_ui <- function(id, lan = NULL) {
           style = "margin-left: 5px",
           icon = icon("check-square")
         ),
-        
+
         actionButton(
           inputId = ns("change_selected_pwds"),
           label = lan$get("Force selected users to change password"),
           class = "btn-primary pull-right disabled",
           icon = icon("key")
         ),
-        
+
         if("db" %in% get_download()){
           list(
             tags$br(),tags$br(), tags$br(), tags$hr(),
-            
+
             downloadButton(
               outputId = ns("download_sql_database"),
               label = lan$get("Download SQL database"),
@@ -112,9 +112,9 @@ admin_ui <- function(id, lan = NULL) {
             )
           )
         },
-        
+
         tags$br(),tags$br()
-        
+
       )
     )
   )
@@ -127,19 +127,19 @@ admin_ui <- function(id, lan = NULL) {
 #' @importFrom RSQLite SQLite
 admin <- function(input, output, session, sqlite_path, passphrase, lan,
                   inputs_list = NULL, max_users = NULL) {
-  
+
   ns <- session$ns
   jns <- function(x) {
     paste0("#", ns(x))
   }
-  
+
   token_start <- isolate(getToken(session = session))
-  
+
   update_read_db <- reactiveValues(x = NULL)
-  
+
   # read users table from database
   users <- reactiveVal(NULL)
-  
+
   observe({
     update_read_db$x
     db <- try({
@@ -154,16 +154,16 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       users(db)
     }
   })
-  
+
   # prevent bug having multiple admin session
   users_update <- reactiveFileReader(1000, session, sqlite_path, filelReaderDB,  passphrase = passphrase, name = "credentials")
   observe({
     if(!is.null(users_update())) users(users_update())
   })
-  
+
   # read password management table from database
   pwds <- reactiveVal(NULL)
-  
+
   observe({
     update_read_db$x
     db <- try({
@@ -178,24 +178,24 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       pwds(db)
     }
   })
-  
+
   # prevent bug having multiple admin session
   pwds_update <- reactiveFileReader(1000, session, sqlite_path, filelReaderDB,  passphrase = passphrase, name = "pwd_mngt")
   observe({
     if(!is.null(pwds_update())) pwds(pwds_update())
   })
-  
-  
+
+
   # displaying users table
   output$table_users <- renderDT({
     req(users())
-    
+
     unbindDT(ns("table_users"))
-    
+
     users <- users()
     users <- users[, setdiff(names(users), c("password", "is_hashed_password")), drop = FALSE]
-    users$Edit <- input_btns(ns("edit_user"), users$user, "Edit user", icon("edit"), status = "primary", lan = lan())
-    users$Remove <- input_btns(ns("remove_user"), users$user, "Delete user", icon("trash-alt"), status = "danger", lan = lan())
+    users$Edit <- input_btns(ns("edit_user"), users$user, "Edit user", icon("pen"), status = "primary", lan = lan())
+    users$Remove <- input_btns(ns("remove_user"), users$user, "Delete user", icon("trash-can"), status = "danger", lan = lan())
     users$Select <- input_checkbox_ui(ns("select_mult_users"), users$user, session = session)
     names_lan <- sapply(names(users), function(x) lan()$get(x))
     change <- as.logical(users$admin)
@@ -227,8 +227,8 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       )
     )
   }, server = FALSE)
-  
-  
+
+
   observeEvent(input$select_all_users, {
     input_names <- names(input)
     select_mult_users_names <- grep("^select_mult_users", input_names, value = TRUE)
@@ -243,21 +243,21 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       })
     }
   })
-  
+
   # displaying password management table
   output$table_pwds <- renderDT({
     req(pwds())
-    
+
     unbindDT(ns("table_pwds"))
-    
+
     pwds <- pwds()
-    
+
     if("n_wrong_pwd" %in% colnames(pwds)){
       pwds$n_wrong_pwd <- NULL
     }
-    
+
     pwds$`Change password` <- input_btns(ns("change_pwd"), pwds$user, "Ask to change password", icon("key"), status = "primary", lan = lan())
-    pwds$`Reset password` <- input_btns(ns("reset_pwd"), pwds$user, "Reset password", icon("undo"), status = "warning", lan = lan())
+    pwds$`Reset password` <- input_btns(ns("reset_pwd"), pwds$user, "Reset password", icon("rotate-left"), status = "warning", lan = lan())
     pwds$Select <- input_checkbox_ui(ns("change_mult_pwds"), pwds$user, session = session)
     names_lan <- sapply(names(pwds), function(x) lan()$get(x))
     change <- as.logical(pwds$must_change)
@@ -290,7 +290,7 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       )
     )
   }, server = FALSE)
-  
+
   observeEvent(input$change_selected_allusers, {
     input_names <- names(input)
     chge_mult_pwds_input <- input_names[grep("^change_mult_pwds", input_names)]
@@ -300,7 +300,7 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       })
     }
   })
-  
+
   # Remove all selected users
   r_selected_users <- callModule(module = input_checkbox, id = "select_mult_users")
   observeEvent(r_selected_users(), {
@@ -317,11 +317,11 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       toggleBtn(session = session, inputId = ns("edit_selected_users"), type = "disable")
     }
   })
-  
+
   observeEvent(input$remove_selected_users, {
     remove_modal(ns("delete_selected_users"), r_selected_users(), lan())
   })
-  
+
   observeEvent(input$delete_selected_users, {
     users <- users()
     to_delete <- r_selected_users()
@@ -334,8 +334,8 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
     write_db_encrypt(conn = conn, value = pwds, name = "pwd_mngt", passphrase = passphrase)
     update_read_db$x <- Sys.time()
   })
-  
-  
+
+
   # Force change password all selected users
   r_selected_pwds <- callModule(module = input_checkbox, id = "change_mult_pwds")
   observeEvent(r_selected_pwds(), {
@@ -346,11 +346,11 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       toggleBtn(session = session, inputId = ns("change_selected_pwds"), type = "disable")
     }
   })
-  
+
   observeEvent(input$change_selected_pwds, {
     change_pwd_modal(ns("changed_password_users"), r_selected_pwds(), lan())
   })
-  
+
   observeEvent(input$changed_password_users, {
     res_chg <- try(force_chg_pwd(r_selected_pwds()), silent = TRUE)
     if (inherits(res_chg, "try-error")) {
@@ -360,12 +360,12 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       update_read_db$x <- Sys.time()
     }
   })
-  
-  
-  
-  
+
+
+
+
   # EDIT USER: launch modal to edit informations about a user ----
-  
+
   observeEvent(input$edit_user, {
     users <- users()
     showModal(modalDialog(
@@ -383,9 +383,9 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       )
     ))
   })
-  
+
   value_edited <- callModule(module = edit_user, id = "edit_user")
-  
+
   # warning message if user already exist in database
   observeEvent(value_edited$user, {
     req(!is.null(value_edited$user$user))
@@ -398,7 +398,7 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
         ui = tags$div(
           id = ns("alert-edituser-exist"),
           class = "alert alert-warning",
-          icon("exclamation-triangle"),
+          icon("triangle-exclamation"),
           lan()$get("User already exist!")
         ),
         immediate = TRUE
@@ -410,7 +410,7 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       toggleBtn(session = session, inputId = ns("edited_user"), type = "enable")
     }
   })
-  
+
   # Write in database edited values for the user
   observeEvent(input$edited_user, {
     users <- users()
@@ -418,7 +418,7 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
     newval <- value_edited$user
     conn <- dbConnect(SQLite(), dbname = sqlite_path)
     on.exit(dbDisconnect(conn))
-    
+
     res_edit <- try({
       users <- update_user(users, newval, input$edit_user)
       write_db_encrypt(conn = conn, value = users, name = "credentials", passphrase = passphrase)
@@ -434,10 +434,10 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       update_read_db$x <- Sys.time()
     }
   })
-  
-  
-  
-  
+
+
+
+
   # EDIT MULTIPLE USERS: Launch modal to edit multiple users ----
   observeEvent(input$edit_selected_users, {
     users <- users()
@@ -455,9 +455,9 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       )
     ))
   })
-  
+
   value_mult_edited <- callModule(module = edit_user, id = "edit_mult_user")
-  
+
   observeEvent(input$edited_mult_user, {
     users <- users()
     newval <- value_mult_edited$user
@@ -477,8 +477,8 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       update_read_db$x <- Sys.time()
     }
   })
-  
-  
+
+
   # ADD NEW USER: launch modal to add a new user ----
   observeEvent(input$add_user, {
     users <- users()
@@ -506,9 +506,9 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       ))
     }
   })
-  
+
   value_added <- callModule(module = edit_user, id = "add_user")
-  
+
   # warning message if user already exist in database
   observeEvent(value_added$user, {
     req(!is.null(value_added$user$user))
@@ -521,7 +521,7 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
         ui = tags$div(
           id = ns("alert-user-exist"),
           class = "alert alert-warning",
-          icon("exclamation-triangle"),
+          icon("triangle-exclamation"),
           lan()$get("User already exist!")
         ),
         immediate = TRUE
@@ -533,7 +533,7 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       toggleBtn(session = session, inputId = ns("added_user"), type = "enable")
     }
   })
-  
+
   # write in database the new user and display his password
   observeEvent(input$added_user, {
     users <- users()
@@ -546,7 +546,7 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
     }
     conn <- dbConnect(SQLite(), dbname = sqlite_path)
     on.exit(dbDisconnect(conn))
-    
+
     # password <- generate_pwd()
     # newuser$password <- password
     res_add <- try({
@@ -586,13 +586,13 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       update_read_db$x <- Sys.time()
     }
   })
-  
-  
+
+
   # launch modal to force a user to change password
   observeEvent(input$change_pwd, {
     change_pwd_modal(ns("changed_password"), input$change_pwd, lan())
   })
-  
+
   # store in database that the user must change password on next connection
   observeEvent(input$changed_password, {
     res_chg <- try(force_chg_pwd(input$change_pwd), silent = TRUE)
@@ -603,8 +603,8 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       update_read_db$x <- Sys.time()
     }
   })
-  
-  
+
+
   # launch modal to reset password
   observeEvent(input$reset_pwd, {
     reset_pwd_modal(ns("reseted_password"), input$reset_pwd, lan())
@@ -634,8 +634,8 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       update_read_db$x <- Sys.time()
     }
   })
-  
-  
+
+
   # launch modal to remove a user from the database
   observeEvent(input$remove_user, {
     current_user <- .tok$get_user(token_start)
@@ -649,7 +649,7 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       remove_modal(ns("delete_user"), input$remove_user, lan())
     }
   })
-  
+
   # delete the user
   observeEvent(input$delete_user, {
     users <- users()
@@ -662,7 +662,7 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
     write_db_encrypt(conn = conn, value = pwds, name = "pwd_mngt", passphrase = passphrase)
     update_read_db$x <- Sys.time()
   })
-  
+
   # download SQL Database
   output$download_sql_database <- downloadHandler(
     filename = function() {
@@ -673,7 +673,7 @@ admin <- function(input, output, session, sqlite_path, passphrase, lan,
       file.copy(sqlite_path, con)
     }
   )
-  
+
   # download user file
   output$download_users_database <- downloadHandler(
     filename = function() {

--- a/R/module-auth.R
+++ b/R/module-auth.R
@@ -11,26 +11,26 @@
 #' @param choose_language \code{logical/character}. Add language selection on top ? TRUE for all supported languages
 #' or a vector of possibilities like \code{c("en", "fr", "pt-BR", "es", "de", "pl")}. If enabled, \code{input$shinymanager_language} is created
 #' @param ... : Used for old version compatibility.
-#' 
-#' 
+#'
+#'
 #' @export
 #'
 #' @name module-authentication
 #'
 #' @importFrom htmltools tagList tags singleton
-#' @importFrom shiny NS fluidRow column textInput passwordInput actionButton uiOutput 
+#' @importFrom shiny NS fluidRow column textInput passwordInput actionButton uiOutput
 #'
 #' @example examples/module-auth.R
-auth_ui <- function(id, status = "primary", tags_top = NULL, 
-                    tags_bottom = NULL, background = NULL, 
+auth_ui <- function(id, status = "primary", tags_top = NULL,
+                    tags_bottom = NULL, background = NULL,
                     choose_language = NULL, lan = NULL, ...) {
-  
+
   ns <- NS(id)
-  
+
   if(is.null(lan)){
     lan <- use_language()
   }
-  
+
   # patch / message changing tag_img & tag_div
   deprecated <- list(...)
   if("tag_img" %in% names(deprecated)){
@@ -61,7 +61,7 @@ auth_ui <- function(id, status = "primary", tags_top = NULL,
             tags$div(
               class = "panel-body",
               {
-                
+
                 choices = lan$get_language()
                 lan_registered <- lan$get_language_registered()
                 if(is.logical(choose_language) && choose_language){
@@ -69,7 +69,7 @@ auth_ui <- function(id, status = "primary", tags_top = NULL,
                 } else if(is.character(choose_language)){
                   choices = unique(c(intersect(choose_language, unname(lan$get_language_registered())), lan$get_language()))
                 }
-                
+
                 names(choices) <- choices
                 for(i in 1:length(choices)){
                   ind <- which(lan_registered %in% choices[i])
@@ -77,7 +77,7 @@ auth_ui <- function(id, status = "primary", tags_top = NULL,
                     names(choices)[i] <- names(lan_registered)[ind]
                   }
                 }
-                selected = ifelse(lan$get_language() %in% choices, 
+                selected = ifelse(lan$get_language() %in% choices,
                                   lan$get_language(),
                                   choices[1])
                 if(length(choices) == 1){
@@ -153,10 +153,10 @@ auth_ui <- function(id, status = "primary", tags_top = NULL,
 #'   \item \strong{expired} : logical, is user has expired ? Always \code{FALSE} if \code{db} doesn't have a \code{expire} column. Optional.
 #'   \item \strong{authorized} : logical, is user can access to his app ? Always \code{TRUE} if \code{db} doesn't have a \code{applications} column. Optional.
 #'  }
-#'  
+#'
 #' @param use_token Add a token in the URL to check authentication. Should not be used directly.
 #' @param lan A language object. See  \code{\link{use_language}}
-#' 
+#'
 #' @export
 #'
 #' @rdname module-authentication
@@ -171,16 +171,16 @@ auth_ui <- function(id, status = "primary", tags_top = NULL,
 #' @importFrom htmltools tags
 #' @importFrom shiny reactiveValues observeEvent removeUI updateQueryString insertUI is.reactive icon updateActionButton updateTextInput renderUI
 #' @importFrom stats setNames
-auth_server <- function(input, output, session, 
-                        check_credentials, 
+auth_server <- function(input, output, session,
+                        check_credentials,
                         use_token = FALSE, lan = NULL) {
-  
+
   ns <- session$ns
   jns <- function(x) {
     paste0("#", ns(x))
   }
-  
-  
+
+
   if(!is.reactive(lan)){
     if(is.null(lan)){
       lan <- reactiveVal(use_language())
@@ -188,56 +188,56 @@ auth_server <- function(input, output, session,
       lan <- reactiveVal(lan)
     }
   }
-  
-  
+
+
   observe({
     session$sendCustomMessage(
       type = "focus_input",
       message = list(inputId = ns("user_id"))
     )
   })
-  
+
   observe({
     if(!is.null(input$language)){
-      lan()$set_language(input$language) 
+      lan()$set_language(input$language)
       updateTextInput(session, inputId = "user_id", label = lan()$get("Username:"))
       updateTextInput(session, inputId = "user_pwd", label = lan()$get("Password:"))
       updateActionButton(session, inputId = "go_auth", label = lan()$get("Login"))
-      
+
       session$sendCustomMessage(
         type = "update_auth_title",
         message = list(
-          inputId = ns("shinymanager-auth-head"), 
+          inputId = ns("shinymanager-auth-head"),
           title = lan()$get("Please authenticate")
         )
       )
-      
+
       output$update_shinymanager_language <- renderUI({
         shinymanager_language(lan()$get_language())
       })
-      
+
       output$label_language <- renderUI({
-        tags$p(paste0(lan()$get("Language"), " :"), 
+        tags$p(paste0(lan()$get("Language"), " :"),
                style = "text-align: right; font-style: italic; margin-top:5px")
       })
-      
+
     }
   })
-  
-  
+
+
   authentication <- reactiveValues(result = FALSE, user = NULL, user_info = NULL)
-  
+
   observeEvent(input$go_auth, {
     removeUI(selector = jns("msg_auth"))
     res_auth <- check_credentials(input$user_id, input$user_pwd)
-    
+
     # locked account ?
     locked <- FALSE
     pwd_failure_limit <- as.numeric(get_pwd_failure_limit())
     if(length(pwd_failure_limit) > 0 && !is.na(pwd_failure_limit) && !is.infinite(pwd_failure_limit)){
       locked <- check_locked_account(input$user_id, pwd_failure_limit)
     }
-    
+
     if (isTRUE(res_auth$result) & !locked) {
       removeUI(selector = jns("auth-mod"))
       authentication$result <- TRUE
@@ -245,26 +245,26 @@ auth_server <- function(input, output, session,
       authentication$user_info <- res_auth$user_info
       # token <- generate_token(input$user_id)
       token <- .tok$generate(input$user_id)
-      
+
       if (isTRUE(use_token)) {
         # add_token(token, as.list(res_auth$user_info))
         .tok$add(token, as.list(res_auth$user_info))
         addAuthToQuery(session, token, lan()$get_language())
         session$reload()
       }
-      
+
     } else if (isTRUE(res_auth$result) & locked) {
-      
+
       save_logs_failed(input$user_id, status = "Locked Account")
-      
+
       insertUI(
         selector = jns("result_auth"),
         ui = tags$div(
           id = ns("msg_auth"), class = "alert alert-danger",
-          icon("exclamation-triangle"), lan()$get("Your account is locked")
+          icon("triangle-exclamation"), lan()$get("Your account is locked")
         )
       )
-      
+
     } else {
       if (is.null(res_auth$user_info)) {
         save_logs_failed(input$user_id, status = "Unknown user")
@@ -272,7 +272,7 @@ auth_server <- function(input, output, session,
           selector = jns("result_auth"),
           ui = tags$div(
             id = ns("msg_auth"), class = "alert alert-danger",
-            icon("exclamation-triangle"), lan()$get("Username or password are incorrect")
+            icon("triangle-exclamation"), lan()$get("Username or password are incorrect")
           )
         )
       } else if (isTRUE(res_auth$expired)) {
@@ -281,7 +281,7 @@ auth_server <- function(input, output, session,
           selector = jns("result_auth"),
           ui = tags$div(
             id = ns("msg_auth"), class = "alert alert-danger",
-            icon("exclamation-triangle"), lan()$get("Your account has expired")
+            icon("triangle-exclamation"), lan()$get("Your account has expired")
           )
         )
       } else {
@@ -291,19 +291,19 @@ auth_server <- function(input, output, session,
             selector = jns("result_auth"),
             ui = tags$div(
               id = ns("msg_auth"), class = "alert alert-danger",
-              icon("exclamation-triangle"), lan()$get("You are not authorized for this application")
+              icon("triangle-exclamation"), lan()$get("You are not authorized for this application")
             )
           )
         } else {
-          
+
           save_logs_failed(input$user_id, status = "Wrong pwd")
-          
+
           if(!locked){
             insertUI(
               selector = jns("result_auth"),
               ui = tags$div(
                 id = ns("msg_auth"), class = "alert alert-danger",
-                icon("exclamation-triangle"), lan()$get("Username or password are incorrect")
+                icon("triangle-exclamation"), lan()$get("Username or password are incorrect")
               )
             )
           } else {
@@ -311,7 +311,7 @@ auth_server <- function(input, output, session,
               selector = jns("result_auth"),
               ui = tags$div(
                 id = ns("msg_auth"), class = "alert alert-danger",
-                icon("exclamation-triangle"), lan()$get("Your account is locked")
+                icon("triangle-exclamation"), lan()$get("Your account is locked")
               )
             )
           }
@@ -319,7 +319,7 @@ auth_server <- function(input, output, session,
       }
     }
   }, ignoreInit = TRUE)
-  
+
   return(authentication)
 }
 

--- a/R/module-pwd.R
+++ b/R/module-pwd.R
@@ -56,7 +56,7 @@ pwd_ui <- function(id, tag_img = NULL, status = "primary", lan = NULL) {
               ),
               tags$span(
                 class = "help-block",
-                icon("info-circle"),
+                icon("circle-info"),
                 lan$get("Password must contain at least one number, one lowercase, one uppercase and must be at least length 6.")
               ),
               tags$br(),
@@ -94,7 +94,7 @@ pwd_ui <- function(id, tag_img = NULL, status = "primary", lan = NULL) {
 #'  one uppercase and be of length 6 at least.
 #' @param use_token Add a token in the URL to check authentication. Should not be used directly.
 #' @param lan An langauge object. Should not be used directly.
-#' 
+#'
 #' @export
 #'
 #' @rdname module-password
@@ -102,7 +102,7 @@ pwd_ui <- function(id, tag_img = NULL, status = "primary", lan = NULL) {
 #' @importFrom htmltools tags
 #' @importFrom shiny reactiveValues observeEvent removeUI insertUI icon actionButton
 #' @importFrom utils getFromNamespace
-pwd_server <- function(input, output, session, user, update_pwd, validate_pwd = NULL, 
+pwd_server <- function(input, output, session, user, update_pwd, validate_pwd = NULL,
                        use_token = FALSE, lan = NULL) {
 
   if(!is.reactive(lan)){
@@ -112,7 +112,7 @@ pwd_server <- function(input, output, session, user, update_pwd, validate_pwd = 
       lan <- reactive(lan)
     }
   }
-  
+
   if (is.null(validate_pwd)) {
     validate_pwd <- getFromNamespace("validate_pwd", "shinymanager")
   }
@@ -127,13 +127,13 @@ pwd_server <- function(input, output, session, user, update_pwd, validate_pwd = 
   observeEvent(input$update_pwd, {
     password$relog <- NULL
     removeUI(selector = jns("msg_pwd"))
-  
+
     if (!identical(input$pwd_one, input$pwd_two)) {
       insertUI(
         selector = jns("result_pwd"),
         ui = tags$div(
           id = ns("msg_pwd"), class = "alert alert-danger",
-          icon("exclamation-triangle"), lan()$get("The two passwords are different")
+          icon("triangle-exclamation"), lan()$get("The two passwords are different")
         )
       )
     } else if (!check_new_pwd(user$user, input$pwd_one)) {
@@ -141,7 +141,7 @@ pwd_server <- function(input, output, session, user, update_pwd, validate_pwd = 
         selector = jns("result_pwd"),
         ui = tags$div(
           id = ns("msg_pwd"), class = "alert alert-danger",
-          icon("exclamation-triangle"), lan()$get("New password cannot be the same as old")
+          icon("triangle-exclamation"), lan()$get("New password cannot be the same as old")
         )
       )
     } else {
@@ -150,7 +150,7 @@ pwd_server <- function(input, output, session, user, update_pwd, validate_pwd = 
           selector = jns("result_pwd"),
           ui = tags$div(
             id = ns("msg_pwd"), class = "alert alert-danger",
-            icon("exclamation-triangle"), lan()$get("Password does not respect safety requirements")
+            icon("triangle-exclamation"), lan()$get("Password does not respect safety requirements")
           )
         )
       } else {
@@ -179,7 +179,7 @@ pwd_server <- function(input, output, session, user, update_pwd, validate_pwd = 
             selector = jns("result_pwd"),
             ui = tags$div(
               id = ns("msg_pwd"), class = "alert alert-danger",
-              icon("exclamation-triangle"), lan()$get("Failed to update password")
+              icon("triangle-exclamation"), lan()$get("Failed to update password")
             )
           )
         }

--- a/R/secure-app.R
+++ b/R/secure-app.R
@@ -91,7 +91,7 @@ secure_app <- function(ui,
             shinymanager_where("admin")
           ),
           tabPanel(
-            title = tagList(icon("home"), lan$get("Home")),
+            title = tagList(icon("house"), lan$get("Home")),
             value = "home",
             admin_ui("admin", lan),
             shinymanager_language(lan$get_language())

--- a/R/secure-app.R
+++ b/R/secure-app.R
@@ -80,7 +80,7 @@ secure_app <- function(ui,
               actionButton(
                 inputId = ".shinymanager_logout",
                 label = lan$get("Logout"),
-                icon = icon("sign-out-alt")
+                icon = icon("right-from-bracket")
               ),
               actionButton(
                 inputId = ".shinymanager_app",
@@ -109,12 +109,12 @@ secure_app <- function(ui,
             actionButton(
               inputId = ".shinymanager_logout",
               label = lan$get("Logout"),
-              icon = icon("sign-out-alt")
+              icon = icon("right-from-bracket")
             ),
             actionButton(
               inputId = ".shinymanager_admin",
               label = lan$get("Administrator mode"),
-              icon = icon("cogs")
+              icon = icon("gears")
             )
           )
         } else {
@@ -126,7 +126,7 @@ secure_app <- function(ui,
             actionButton(
               inputId = ".shinymanager_logout",
               label = lan$get("Logout"),
-              icon = icon("sign-out-alt")
+              icon = icon("right-from-bracket")
             )
           )
         }
@@ -196,23 +196,23 @@ secure_app <- function(ui,
 #'      )
 #' )
 #' }
-#' 
+#'
 #' You can specify if you want to allow downloading users file,  sqlite database and logs from within
 #' the admin panel by invoking \code{options("shinymanager.download")}. It defaults
-#' to \code{c("db", "logs", "users")}, that allows downloading all. You can specify 
+#' to \code{c("db", "logs", "users")}, that allows downloading all. You can specify
 #' \code{options("shinymanager.download" = "db"} if you want allow admin to download only
 #' sqlite database, \code{options("shinymanager.download" = "logs")} to allow logs download
-#' or \code{options("shinymanager.download" = "")} to disable all.  
+#' or \code{options("shinymanager.download" = "")} to disable all.
 #'
 #' Using \code{options("shinymanager.pwd_validity")}, you can set password validity period. It defaults
 #' to \code{Inf}. You can specify for example
 #' \code{options("shinymanager.pwd_validity" = 90)} if you want to force user changing password each 90 days.
-#' 
+#'
 #' Using \code{options("shinymanager.pwd_failure_limit")}, you can set password failure limit. It defaults
 #' to \code{Inf}. You can specify for example
 #' \code{options("shinymanager.pwd_failure_limit" = 5)} if you want to lock user account after 5 wrong password.
-#' 
-#' 
+#'
+#'
 #' @export
 #'
 #' @importFrom shiny callModule getQueryString parseQueryString
@@ -229,12 +229,12 @@ secure_server <- function(check_credentials,
                           session = shiny::getDefaultReactiveDomain()) {
 
   session$setBookmarkExclude(c(session$getBookmarkExclude(),
-                               "shinymanager_language", 
-                               ".shinymanager_timeout", 
+                               "shinymanager_language",
+                               ".shinymanager_timeout",
                                ".shinymanager_admin",
-                               ".shinymanager_logout", 
+                               ".shinymanager_logout",
                                "shinymanager_where"))
-  
+
   token_start <- isolate(getToken(session = session))
   if (isTRUE(keep_token)) {
     .tok$reset_count(token_start)

--- a/dev/shinydashboard/ui.R
+++ b/dev/shinydashboard/ui.R
@@ -8,8 +8,8 @@ ui <- dashboardPage(
 
   dashboardSidebar(
     sidebarMenu(
-      menuItem("Dashboard", tabName = "dashboard", icon = icon("dashboard")),
-      menuItem("Widgets", tabName = "widgets", icon = icon("th"))
+      menuItem("Dashboard", tabName = "dashboard", icon = icon("gauge")),
+      menuItem("Widgets", tabName = "widgets", icon = icon("table-cells"))
     )
   ),
 

--- a/examples/fab_button.R
+++ b/examples/fab_button.R
@@ -18,7 +18,7 @@ ui <- fluidPage(
     actionButton(
       inputId = "logout",
       label = "Logout",
-      icon = icon("sign-out")
+      icon = icon("right-from-bracket")
     ),
     actionButton(
       inputId = "info",


### PR DESCRIPTION
Change all names that gave a warning to current ones, e.g

```
The `name` provided ('sign-out') is deprecated in Font Awesome 6:
* please consider using 'right-from-bracket' or 'fas fa-right-from-bracket' instead
* use the `verify_fa = FALSE` to deactivate these messages
```



