### PR TITLE
Patch edit user

### DIFF
--- a/R/language.R
+++ b/R/language.R
@@ -688,7 +688,7 @@ pkgEnv$label_el = list(
   "Allowed null values" = "\u0395\u03c0\u03b9\u03c4\u03c1\u03b5\u03c0\u03cc\u03bc\u03b5\u03bd\u03b5\u03c2 \u03bc\u03b7\u03b4\u03b5\u03bd\u03b9\u03ba\u03ad\u03c2 (null) \u03c4\u03b9\u03bc\u03ad\u03c2"
 )
 
-v_language_registered = c("en", "fr", "pt-BR", "es", "de", "pl", "ja", "el", "el")
+v_language_registered = c("en", "fr", "pt-BR", "es", "de", "pl", "ja", "el")
 names(v_language_registered) = c("English", "Fran\u00e7ais", "Portuguese", "Espa\u00f1ol", "Deutsch", "Polski", "\u65e5\u672c\u8a9e", "\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac")
 
 
@@ -730,6 +730,9 @@ language <- R6::R6Class(
     get_DT = function() {
       private$DT_lan[[private$language]]
     },
+    get_dateInput = function() {
+      private$dateInput_lan[[private$language]]
+    },
     get_language_registered = function() {
       private$language_registered
     },
@@ -741,6 +744,16 @@ language <- R6::R6Class(
     language = "en",
     language_registered = v_language_registered,
     labels = pkgEnv$label_en,
+    dateInput_lan = list(
+      "en" = "en",
+      "fr" = "fr",
+      "pt-BR" = "pt-BR",
+      "es" = "es",
+      "de" = "de",
+      "pl" = "pl",
+      "ja" = "ja",
+      "el" = "el"
+    ),
     DT_lan = list(
       fr = list(
         sProcessing = "Traitement en cours...", sSearch = "Rechercher&nbsp;:",

--- a/R/module-edit_user.R
+++ b/R/module-edit_user.R
@@ -24,8 +24,7 @@ edit_user_ui <- function(id, credentials, username = NULL, inputs_list = NULL, l
     FUN = function(x) {
       if (identical(x, "start")) {
         value <- unique(data_user[[x]])
-        if (is.null(value) || length(value) > 1) {
-          # value <- Sys.Date()
+        if (is.null(value) || length(value) != 1) {
           value <- NA
         }
         suppressWarnings({
@@ -33,7 +32,7 @@ edit_user_ui <- function(id, credentials, username = NULL, inputs_list = NULL, l
         })
       } else if (identical(x, "expire")) {
         value <- unique(data_user[[x]])
-        if (is.null(value) || length(value) > 1) {
+        if (is.null(value) || length(value) != 1) {
           # value <- Sys.Date() + 60
           value <- NA
         }

--- a/R/module-edit_user.R
+++ b/R/module-edit_user.R
@@ -78,7 +78,7 @@ edit_user_ui <- function(id, credentials, username = NULL, inputs_list = NULL, l
             list_args$selected <- NULL
           } else {
             if (!is.null(username)){
-              if (list_args$multiple && is.character(data_user[[x]])) {
+              if (isTRUE(list_args$multiple) && is.character(data_user[[x]])) {
                 list_args$selected <- unlist(strsplit(data_user[[x]], ";"))
               } else {
                 list_args$selected <- data_user[[x]]
@@ -141,7 +141,7 @@ edit_user_ui <- function(id, credentials, username = NULL, inputs_list = NULL, l
       width = "100%"
     )
   }
-  
+
   tagList(
     input_list
   )

--- a/R/module-edit_user.R
+++ b/R/module-edit_user.R
@@ -28,7 +28,13 @@ edit_user_ui <- function(id, credentials, username = NULL, inputs_list = NULL, l
           value <- NA
         }
         suppressWarnings({
-          dateInput(inputId = ns(x), label = R.utils::capitalize(lan$get("start")), value = value, width = "100%")
+          dateInput(
+            inputId = ns(x),
+            label = R.utils::capitalize(lan$get("start")),
+            value = value,
+            language = lan$get_dateInput(),
+            width = "100%"
+          )
         })
       } else if (identical(x, "expire")) {
         value <- unique(data_user[[x]])
@@ -37,7 +43,13 @@ edit_user_ui <- function(id, credentials, username = NULL, inputs_list = NULL, l
           value <- NA
         }
         suppressWarnings({
-          dateInput(inputId = ns(x), label = R.utils::capitalize(lan$get("expire")), value = value, width = "100%")
+          dateInput(
+            inputId = ns(x),
+            label = R.utils::capitalize(lan$get("expire")),
+            value = value,
+            language = lan$get_dateInput(),
+            width = "100%"
+          )
         })
       } else if (identical(x, "user") && length(username) > 1) {
         NULL # MULTIPLE USERS: dont modify user name

--- a/R/module-edit_user.R
+++ b/R/module-edit_user.R
@@ -54,7 +54,7 @@ edit_user_ui <- function(id, credentials, username = NULL, inputs_list = NULL, l
           checkboxInput(
             inputId = ns(x),
             label = R.utils::capitalize(lan$get("admin")),
-            value = isTRUE(all(as.logical(data_user[[x]])))
+            value = isTRUE(all(as.logical(data_user[[x]]))) & length(data_user[[x]])
           )
         }
       } else {


### PR DESCRIPTION
Fixes some issues in edit user module : 
* App crash when using `selectInput` in `secure_server(inputs_list = )` and not specifying `multiple`
* Admin checkbox was checked by default when adding a new user because of `all(logical(0))` being `TRUE`
* Start & Expire widgets were both set with current day when adding a new user
* added support for language in `dateInput` in edit user module