### PR TITLE
respect is_hashed_password in create_sql_db

### DIFF
--- a/R/credentials-db-sql.R
+++ b/R/credentials-db-sql.R
@@ -163,8 +163,22 @@ write_sql_db <- function(config_db, value, name = "credentials") {
   name <- SQL(name)
   
   if("password" %in% colnames(value)){
-    # store hashed password
-    value$password <- sapply(value$password, function(x) scrypt::hashPassword(x))
+    # is_hashed_password is a column from storing credentials in SQLite.
+    if("is_hashed_password" %in% colnames(value)){
+      value$password <- mapply(function(pwd, is_hashed){
+        if(as.logical(is_hashed)){
+          # So, the passwords may already be hashed.
+          pwd
+        } else {
+          scrypt::hashPassword(pwd)
+        }
+      }, value$password, value$is_hashed_password)
+      value$is_hashed_password <- T
+    } else {
+      # Any clients since the addition of SQL support in version 1.0.5 won't have the
+      # is_hashed_password column (unless they specify it explicitly in their db config)
+      value$password <- sapply(value$password, function(x) scrypt::hashPassword(x))
+    }
   }
   
   if("MariaDBConnection" %in% class(conn)){


### PR DESCRIPTION
With the support of PostgreSQL backends (among others) in version 1.0.500, we should be able to port SQLite credentials over to the new tables while respecting is_hashed_password column (if it exists).

This will respect the `is_hashed_password` column by checking its existence/value before hashing. Otherwise, the password is assumed to be plaintext.

Clients migrating from SQLite will be able to use existing credentials without forcing users to reset their passwords.