### PR TITLE
Add MS SQL Server support

### DIFF
--- a/R/credentials-db-sql.R
+++ b/R/credentials-db-sql.R
@@ -166,7 +166,16 @@ write_sql_db <- function(config_db, value, name = "credentials") {
     # store hashed password
     value$password <- sapply(value$password, function(x) scrypt::hashPassword(x))
   }
-  
+
+  if("Microsoft SQL Server" %in% class(conn)){
+    is_logical <- sapply(value, function(x) "logical" %in% class(x) || all(x %in% c("TRUE", "FALSE")))
+    if(any(is_logical)){
+      for(i in which(is_logical)){
+        value[[i]] <- as.integer(as.logical(value[[i]]))
+      }
+    }
+  }
+                             
   if("MariaDBConnection" %in% class(conn)){
     is_logical <- sapply(value, function(x) "logical" %in% class(x) || all(x %in% c("TRUE", "FALSE")))
     if(any(is_logical)){

--- a/inst/sql_config/sql_template.yml
+++ b/inst/sql_config/sql_template.yml
@@ -1,0 +1,72 @@
+# R packages required for DB connection.
+# Use comma separation for multiple dependencies [package1, package2]
+r_packages: [odbc]
+
+# Optional. Default is false == connect one time per session.
+# True = connect/disconnect each request.
+connect_every_request: false 
+
+# Connection via DBI interface.
+# Access env variables via !expr Sys.getenv("NAME_ENV_VAR").
+connect:
+  drv: !expr odbc::odbc()
+  driver: "ODBC Driver 18 for SQL Server"  # value depends on local environment
+  server: "SERVER_NAME"
+  database: "DB_NAME"
+  port: 1433
+  uid: !expr Sys.getenv("SQL_SERVER_UID")
+  pwd: !expr Sys.getenv("SQL_SERVER_PWD")
+
+# optional / Default
+# disconnect:
+#   fun: "dbDisconnect"
+
+tables:
+  credentials:
+    tablename: SHINY_CREDENTIALS                    # if you want to change tablename
+    # The fields user, password, start, expire, admin are mandatory.
+    # Then add optional custom columns.
+    init: CREATE TABLE {`tablename`} (
+            "user"  varchar(100) PRIMARY KEY, 
+            "password"  varchar(256),         
+            "start"  date,                   
+            "expire" date,                   
+            "admin" BIT,
+            "applications" varchar(512)
+        )
+    # Keep same {glue_name*}, update request only if needed.   
+    select: SELECT * FROM {`tablename`} WHERE "user" IN ({user*})
+    update: UPDATE {`tablename`} SET {`name`} = {value} WHERE "user" IN ({udpate_users*})
+    delete: DELETE FROM {`tablename`} WHERE "user" IN ({del_users*})
+  pwd_mngt:
+    tablename: SHINY_PWDS                       # if you want to change tablename
+    # user, must_change, have_changed, date_change, n_wrong_pwd = mandatory with this name
+    #  No additionnal columns here
+    init: CREATE TABLE {`tablename`} (
+            "user"  varchar(100) PRIMARY KEY, 
+            "must_change"  BIT,           
+            "have_changed"  BIT,        
+            "date_change" date, 
+            "n_wrong_pwd" smallint
+          )
+    # Keep same {glue_name*}, update request only if needed.  
+    select: SELECT * FROM {`tablename`} WHERE "user" IN ({user*})
+    update: UPDATE {`tablename`} SET {`name`} = {value} WHERE "user" IN ({udpate_users*})
+    delete: DELETE FROM {`tablename`} WHERE "user" IN ({del_users*})
+  logs:
+    tablename: SHINY_AUTH_LOGS                          # if you want to change tablename
+    #  all = mandatory with this name
+    #  No additionnal columns here
+    init: CREATE TABLE {`tablename`} (
+            "id" INT IDENTITY(1,1) PRIMARY KEY,
+            "user"  varchar(100),             
+            "server_connected" DATETIMEOFFSET, 
+            "token"  varchar(100),          
+            "logout" DATETIMEOFFSET,          
+            "status"  varchar(100),          
+            "app" varchar(100)               
+          )
+    # Keep same {glue_name*}, update request only if needed. 
+    check_token: SELECT * FROM {`tablename`} WHERE "token" IN ({token*})
+    select: SELECT * FROM {`tablename`} WHERE "user" IN ({user*}) AND "server_connected" >= {`date_h_begin`}  AND "server_connected" <= {`date_h_end`}
+    update: UPDATE {`tablename`} SET {`name`} = {value} WHERE "token" IN ({token*})


### PR DESCRIPTION
Now that version 1.0.510 supports SQL backends, we should be able to target a MS SQL Server DB in addition to other SQL backends.

- [x] Add a `sql_template.yml` with suitable template values for connecting to MS SQL Server and with modified `CREATE TABLE` specifications for holding Boolean values in a suitable SQL Server data type.
- [x] Add a fix to `credentials-db-sql.R`, with logic that is identical to the previous fix for MariaDB, to allow R logical values to be written back via casting into a MS SQL Server `bit` data type.